### PR TITLE
Generate context for mariadbd files

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -28,6 +28,13 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/libexec/mysqld	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/libexec/mysqld_safe-scl-helper --  gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
 
+# mariadb
+
+/usr/bin/mariadbd-safe	--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
+/usr/bin/mariadbd-safe-helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/bin/mariadb-upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+
+/usr/libexec/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/sbin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/sbin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)


### PR DESCRIPTION
Since mariadb-10.5 mariadbd is regular file and mysqld is symlink
pointing on it