### PR TITLE
Allow 'mysqld' to use '/usr/bin/hostname'

### DIFF
--- a/mysql.te
+++ b/mysql.te
@@ -251,6 +251,7 @@ mysql_write_log(mysqld_safe_t)
 
 optional_policy(`
 	hostname_exec(mysqld_safe_t)
+	hostname_exec(mysqld_t)
 ')
 
 ########################################


### PR DESCRIPTION
Resolves:
  https://bugzilla.redhat.com/show_bug.cgi?id=2089664
  https://bugzilla.redhat.com/show_bug.cgi?id=2073386