### PR TITLE
Add mariadb-backup and mariadbd (upstream)

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -35,6 +35,9 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/bin/mariadb-upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/libexec/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/sbin/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+
+/usr/bin/mariadb-backup	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/sbin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/sbin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)


### PR DESCRIPTION
mariadb-backup needs to access raw files so give it the same context as the server.

mariadbd upstream has its path in /usr/sbin/mariadbd so we can add that to the default policy if a user installs an upstream package.

Upstream bug: https://jira.mariadb.org/browse/MDEV-24941

closes: #4