### PR TITLE
Re-add upstream MySQL and MariaDB paths

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -28,8 +28,8 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/libexec/mysqld	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/libexec/mysqld_safe-scl-helper --  gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
 
-
-/usr/bin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+# For upstream packaged MySQL
+/usr/sbin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)
 /usr/bin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
@@ -40,7 +40,8 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/bin/mariadbd-safe-helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/mariadb-upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
-/usr/bin/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+# Fpr the upstream packaged MariaDB
+/usr/sbin/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/libexec/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 


### PR DESCRIPTION
Reverts commit 58faf0fbe89a7783de2900410fa9e89b1cf525ee

The /usr/sbin paths are used by the upstream MySQL and MariaDB packages.

The paths used by Fedora and RHEL are the /usr/libexec path which already has a selinux fcontext.

In an effort not to get these reverted, a comment is added.

I cannot currently find any ndb or mysqlmanager package so I've left these as is.