### PR TITLE
Update fc mariadb and mysql labels for bin sbin and libexec

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -48,7 +48,14 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/bin/mariadbd-safe-helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/mariadb-upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
-/usr/bin/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+# for mariadb upstream which has mariadbd inside of /usr/sbin as a file
+/usr/sbin/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+# for the fedora >= 42 downstream which has mariadbd inside /usr/bin as a
+# symlink to /usr/libexec/mariadbd
+/usr/bin/mariadbd	-l	gen_context(system_u:object_r:mysqld_exec_t,s0)
+# for the fedora <= 41 and rhel downstream, which has mariadbd /usr/sbin as a
+# symlink to /usr/libexec/mariadbd
+/usr/sbin/mariadbd	-l	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/libexec/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 

--- a/mysql.fc
+++ b/mysql.fc
@@ -25,7 +25,12 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/bin/mysqld_safe_helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/mysql_upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
+# for the fedora and rhel downstream mysql package where
+# /usr/libexec/mysqld is a file
 /usr/libexec/mysqld	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+# for the fedora and rhel downstream mariadb package where
+# /usr/libexec/mysqld is a symlink to /usr/libexec/mariadbd
+/usr/libexec/mysqld	-l	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/libexec/mysqld_safe-scl-helper --  gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
 
 # for the oracle upstream rpms which have mysqld inside of /usr/bin as a file

--- a/mysql.fc
+++ b/mysql.fc
@@ -28,8 +28,16 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/libexec/mysqld	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/libexec/mysqld_safe-scl-helper --  gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
 
-
+# for the oracle upstream rpms which have mysqld inside of /usr/bin as a file
+# and not as a symlink
 /usr/bin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+# for the mariadb upstream and fedora >= 41/rhel downstream mariadb and mysql
+# which have mysqld in /usr/sbin as a symlink to /usr/sbin/mariadbd 
+# and /usr/libexec/mysqld respectively
+/usr/sbin/mysqld		-l	gen_context(system_u:object_r:mysqld_exec_t,s0)
+# for the fedora >= 42 downstream which has mysqld inside /usr/bin as a symlink
+# to /usr/libexec/mysqld
+/usr/bin/mysqld		-l	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)
 /usr/bin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 


### PR DESCRIPTION
Adds the labeling rules needed to handle the symlinks and files used by the mariadb and oracle upstreams and redhat downstream regarding the /usr/bin and /usr/sbin directories. Also adds the handling of /usr/libexec/mysld as a file and as a symlink. 
These changes were prompted by the fedora change:
https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin
Prompting us to migrate to /usr/bin but we also need to keep the /usr/sbin file locations for rhel, older fedoras (f41 and lower) and for the mariadb and oracle upstreams.