### PR TITLE
Allow create kerberos files in mysql db home

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -57,6 +57,10 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /var/log/mysql(/.*)?	gen_context(system_u:object_r:mysqld_log_t,s0)
 /var/log/mysql.*	--	gen_context(system_u:object_r:mysqld_log_t,s0)
 
+/var/lib/mysql/\.k5identity		gen_context(system_u:object_r:krb5_home_t,s0)
+/var/lib/mysql/\.k5login		gen_context(system_u:object_r:krb5_home_t,s0)
+/var/lib/mysql/\.k5users		gen_context(system_u:object_r:krb5_home_t,s0)
+
 /run/mariadb(/.*)?      gen_context(system_u:object_r:mysqld_var_run_t,s0)
 /run/mysql(/.*)?		gen_context(system_u:object_r:mysqld_var_run_t,s0)
 /run/mysqld(/.*)?		gen_context(system_u:object_r:mysqld_var_run_t,s0)

--- a/mysql.if
+++ b/mysql.if
@@ -589,6 +589,39 @@ interface(`mysql_filetrans_named_content',`
 
 ########################################
 ## <summary>
+##	Create private objects at postgresql db directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="private type">
+##	<summary>
+##	The type of the object to be created.
+##	</summary>
+## </param>
+## <param name="object">
+##	<summary>
+##	The object class of the object being created.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`mysql_db_filetrans',`
+	gen_require(`
+		type mysql_db_t;
+	')
+
+	filetrans_pattern($1, mysql_db_t, $2, $3, $4)
+')
+
+########################################
+## <summary>
 ##	All of the rules required to administrate an mysql environment
 ## </summary>
 ## <param name="domain">

--- a/mysql.if
+++ b/mysql.if
@@ -74,7 +74,7 @@ interface(`mysql_signull',`
 
 ########################################
 ## <summary>
-##	Allow the specified domain to connect to postgresql with a tcp socket.
+##	Allow the specified domain to connect to mysql with a tcp socket.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -589,7 +589,7 @@ interface(`mysql_filetrans_named_content',`
 
 ########################################
 ## <summary>
-##	Create private objects at postgresql db directory.
+##	Create private objects at mysql db directory.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -614,10 +614,10 @@ interface(`mysql_filetrans_named_content',`
 #
 interface(`mysql_db_filetrans',`
 	gen_require(`
-		type mysql_db_t;
+		type mysqld_db_t;
 	')
 
-	filetrans_pattern($1, mysql_db_t, $2, $3, $4)
+	filetrans_pattern($1, mysqld_db_t, $2, $3, $4)
 ')
 
 ########################################


### PR DESCRIPTION
This mirrors the logic applied to PostgreSQL in commit <b464336f5cefe0feddcc5b6787f4ab718a54bb86>.

Release of this change to be synced with related change in fedora-selinux/selinux-policy as the mysql.fi file is mirrored.