### PR TITLE
Add file context for relocated wsrep_sst_common

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -47,6 +47,9 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 
 /usr/bin/mariadb-backup	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
+# wsrep SST shell function library, sourced by wsrep_sst_* scripts
+/usr/share/mariadb/wsrep_sst_common	--	gen_context(system_u:object_r:mysqld_etc_t,s0)
+
 #
 # /var
 #


### PR DESCRIPTION
MariaDB PR #4871 (MDEV-14296) ( https://github.com/MariaDB/server/pull/4871 ) relocates wsrep_sst_common from /usr/bin/ to /usr/share/mariadb/. This file is a shell function library (no shebang, not directly executable) that is sourced by the wsrep_sst_* SST scripts during Galera state transfer.

Without this policy update, the move breaks SELinux-enforcing systems:

  Before: /usr/bin/wsrep_sst_common inherits bin_t from the base
  policy. mysqld_t can read bin_t files via corecmd_exec_bin().

  After: /usr/share/mariadb/wsrep_sst_common inherits usr_t from
  the base policy. mysqld_t has no explicit read grant for usr_t.
  Sourcing the file (a read operation by bash running in mysqld_t
  domain) produces an AVC denial.

The fix labels the new path as mysqld_etc_t. Both mysqld_t and mysqld_safe_t already have read_file_perms on mysqld_etc_t (mysql.te direct allow rule and mysql_read_config() interface respectively), so no type enforcement changes are needed.

mysqld_etc_t is semantically appropriate: wsrep_sst_common is a read-only auxiliary file that the server needs at runtime, similar in access pattern to configuration files.