### PR TITLE
RHEL-164351: Label auth_pam_tool as chkpwd_exec_t to fix AVC denial

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -47,6 +47,10 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 
 /usr/bin/mariadb-backup	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
+# PAM authentication helper (setuid binary); runs in chkpwd_t domain
+# which already has capability setuid needed for setreuid() calls
+/usr/lib/mariadb/plugin/auth_pam_tool_dir/auth_pam_tool	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
+
 # wsrep SST shell function library, sourced by wsrep_sst_* scripts
 /usr/share/mariadb/wsrep_sst_common	--	gen_context(system_u:object_r:mysqld_etc_t,s0)
 

--- a/mysql.te
+++ b/mysql.te
@@ -160,8 +160,11 @@ tunable_policy(`mysql_connect_http',`
 	corenet_tcp_connect_http_port(mysqld_t)
 ')
 
+# MariaDB's auth_pam_tool runs as chkpwd_t and calls PAM, which
+# invokes unix_chkpwd (also chkpwd_exec_t) to verify passwords.
 optional_policy(`
 	auth_use_pam(mysqld_t)
+	allow chkpwd_t chkpwd_exec_t:file execute_no_trans;
 ')
 
 optional_policy(`


### PR DESCRIPTION
MariaDB's auth_pam_tool is a setuid-root helper binary that
authenticates users via PAM. Without a specific file context, it
inherits lib_t and runs in the mysqld_t domain, which lacks
capability setuid — causing an AVC denial when auth_pam_tool
calls setreuid():

  avc: denied { setuid } for comm="auth_pam_tool" capability=7
    scontext=mysqld_t tcontext=mysqld_t tclass=capability

mysql.fc change:
  Label auth_pam_tool as chkpwd_exec_t. This triggers the
  existing domain transition mysqld_t -> chkpwd_t (set up by
  auth_domtrans_chk_passwd, called from auth_use_pam). The
  chkpwd_t domain already has capability setuid, pipe access
  to mysqld_t, and PAM-related permissions.
  The path uses /usr/lib/ instead of /usr/lib64/ because
  SELinux has an equivalency rule (/usr/lib64 -> /usr/lib);
  /usr/lib64 paths are silently ignored by restorecon.

mysql.te change:
  Allow chkpwd_t to execute chkpwd_exec_t files without a
  domain transition (execute_no_trans). This is needed because
  auth_pam_tool calls PAM, and pam_unix.so internally invokes
  /usr/sbin/unix_chkpwd (also labeled chkpwd_exec_t) to verify
  passwords against /etc/shadow. Without this rule, the nested
  exec produces a second AVC denial:

    avc: denied { execute_no_trans } for comm="auth_pam_tool"
      path="/usr/sbin/unix_chkpwd"
      scontext=chkpwd_t tcontext=chkpwd_exec_t tclass=file

--

Resolves: RHEL-164351

Co-Authored-By: Claude AI <noreply@anthropic.com>
