### PR TITLE
Add explicit lib64 file context for auth_pam_tool

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -50,6 +50,7 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 # PAM authentication helper (setuid binary); runs in chkpwd_t domain
 # which already has capability setuid needed for setreuid() calls
 /usr/lib/mariadb/plugin/auth_pam_tool_dir/auth_pam_tool	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
+/usr/lib64/mariadb/plugin/auth_pam_tool_dir/auth_pam_tool	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
 
 # wsrep SST shell function library, sourced by wsrep_sst_* scripts
 /usr/share/mariadb/wsrep_sst_common	--	gen_context(system_u:object_r:mysqld_etc_t,s0)


### PR DESCRIPTION
Explicitly add the /usr/lib64/ path for auth_pam_tool. While restorecon handles /usr/lib64 -> /usr/lib equivalency rules (as intended in 4df36eb), the %selinux_relabel_post RPM macro uses `fixfiles`, which fails to apply the equivalency rule.

Adding the exact /usr/lib64/ path avoids missing labels during package installation.