### PR TITLE
Added the rules to fix the AVC denials when upgrading between major

### DIFF
--- a/mysql.te
+++ b/mysql.te
@@ -128,6 +128,12 @@ corenet_tcp_connect_tram_port(mysqld_t)
 corenet_sendrecv_mysqld_client_packets(mysqld_t)
 corenet_sendrecv_mysqld_server_packets(mysqld_t)
 
+# Needed for Updating a database between major
+# versions that is run on a galera cluster
+corenet_tcp_bind_kerberos_port(mysqld_t)
+corenet_tcp_bind_all_unreserved_ports(mysqld_t)
+corenet_tcp_connect_all_unreserved_ports(mysqld_t)
+
 dev_read_sysfs(mysqld_t)
 dev_read_urand(mysqld_t)
 


### PR DESCRIPTION
versions of MariaDB on a galera cluster

Resolves: RHEL-171580